### PR TITLE
* order link_type choices alphabetically

### DIFF
--- a/anylink/models.py
+++ b/anylink/models.py
@@ -52,7 +52,7 @@ def do_anylink_extension_setup(cls, **kwargs):
 
     link_type = cls._meta.get_field('link_type')
     link_type.choices.extend(cls.extension_choices)
-    link_type.choices = sorted(link_type.choices, key=lambda item: item[0])
+    link_type.choices.sort(key=lambda item: item[0])
 
     # Manually add display function.
     cls.get_link_type_display = curry(cls._get_FIELD_display, field=link_type)

--- a/anylink/models.py
+++ b/anylink/models.py
@@ -52,6 +52,7 @@ def do_anylink_extension_setup(cls, **kwargs):
 
     link_type = cls._meta.get_field('link_type')
     link_type.choices.extend(cls.extension_choices)
+    link_type.choices = sorted(link_type.choices, key=lambda item: item[0])
 
     # Manually add display function.
     cls.get_link_type_display = curry(cls._get_FIELD_display, field=link_type)


### PR DESCRIPTION
With this PR link_type.choices will be sorted alphabetically to avoid generating new migrations without model changes.