### PR TITLE
Fix multi use feature

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include pytest.ini
 include setup.cfg
 
 recursive-include anylink *.py
+recursive-include anylink/locale **
 recursive-include anylink/static/anylink *.js
 recursive-include anylink/static/tiny_mce/plugins **
 recursive-include anylink/templates/admin/anylink/anylink *.html

--- a/anylink/forms.py
+++ b/anylink/forms.py
@@ -4,7 +4,6 @@ from django.utils.encoding import force_text
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
-# from .compat import add_error
 from .models import AnyLink
 
 

--- a/anylink/forms.py
+++ b/anylink/forms.py
@@ -4,7 +4,7 @@ from django.utils.encoding import force_text
 from django.utils.translation import ugettext
 from django.utils.translation import ugettext_lazy as _
 
-from .compat import add_error
+# from .compat import add_error
 from .models import AnyLink
 
 
@@ -25,10 +25,11 @@ class AnyLinkAdminForm(forms.ModelForm):
             if len(objects) > 1 and not data.get('confirmation'):
                 self.fields['confirmation'].widget = forms.CheckboxInput()
                 self.fields['confirmation'].required = True
-                add_error(self, 'confirmation', ugettext('Please confirm your changes.'), data)
+                self.fields['confirmation'].label = ugettext('Please confirm your changes.')
 
                 objects_used = u', '.join([force_text(obj) for obj in objects])
-                msg = ugettext(u'The following objects are using this link already: {0}').format(
-                    objects_used)
+                msg = ugettext(
+                    u'The following objects are using this link already: {0}').format(
+                        objects_used)
                 raise forms.ValidationError(msg)
         return data

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -42,3 +42,13 @@ model needs to have a ``get_absolute_url`` method.
     )
 
 For details on writing your own extensions, please see the :ref:`extension` section.
+
+Link Multiusage
+```````````````
+
+To use anylink instance multiple times set ``ANYLINK_ALLOW_MULTIPLE_USE`` to ``True``
+
+.. code-block:: python
+
+    # Example with app using link multiple times
+    ANYLINK_ALLOW_MULTIPLE_USE = True

--- a/testing/pytests/test_admin.py
+++ b/testing/pytests/test_admin.py
@@ -228,7 +228,6 @@ class TestAnyLinkAdmin:
         field = form.fields['confirmation']
         assert field.required
         assert isinstance(field.widget, forms.CheckboxInput)
-        assert 'confirmation' in form.errors
         assert str(obj1) in form.errors['__all__'][0]
         assert str(obj2) in form.errors['__all__'][0]
         assert str(obj3) not in form.errors['__all__'][0]


### PR DESCRIPTION
Improve formatting of warning message for saving links with multiple usage.
Add locale folder to build to include possibility of internalisation.
Include description of ANYLINK_ALLOW_MULTIPLE_USE in documentation.